### PR TITLE
Noref better bulk id posting

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,8 @@ const makeLogger = function (namespace, options) {
     logToFile: `./logs/${namespace}.log`
   }, options)
 
-  const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug'
+  const logLevel = process.env.LOG_LEVEL ||
+    ((process.env.NODE_ENV === 'production') ? 'info' : 'debug')
 
   let loggerTransports = []
 

--- a/lib/reposter.js
+++ b/lib/reposter.js
@@ -48,19 +48,22 @@ class Reposter {
       limit: 1000,
       batchSize: 100,
       start: '',
+      ids: '',
       lastUpdatedDate: null,
       lastUpdatedDateStop: null,
       onProgress: () => null,
       processingAll: null
     }, options)
 
+    if (options.ids && Array.isArray(options.ids) && options.ids.length === 0) options.ids = null
+
     // If not explicitly set, set `processingAll` to true if neither `start`
     // nor `limit` is set. If either is set, we're not processing everything.
-    if (options.processingAll === null) options.processingAll = !options.start && !options.limit
+    if (options.processingAll === null) options.processingAll = !options.ids && !options.start && !options.limit
 
     // Validate options
     if (!which || ['bibs', 'items'].indexOf(which) < 0) throw new Error('First argument must specify bibs/items')
-    if ((!nyplSource || ['sierra-nypl', 'recap-pul', 'recap-cul'].indexOf(nyplSource) < 0) && !options.lastUpdatedDate) throw new Error('Second argument must specify valid nyplSource')
+    if ((!nyplSource || ['sierra-nypl', 'recap-pul', 'recap-cul', 'recap-hl'].indexOf(nyplSource) < 0) && !options.lastUpdatedDate) throw new Error('Second argument must specify valid nyplSource')
     if (options.limit && (typeof options.limit) !== 'number' || ((typeof options.limit) === 'number' && options.limit <= 0)) throw new Error('Invalid options.limit. Must be numeric')
     if (options.batchSize && (typeof options.batchSize) !== 'number' || options.batchSize <= 0) throw new Error('Invalid batchSize. Must be numeric')
     if (options.batchDelay && (typeof options.batchDelay) !== 'number' || options.batchDelay < 0) throw new Error('Invalid batchDelay. Must be numeric')
@@ -92,9 +95,10 @@ class Reposter {
     // Build params to POST:
     const params = {
       nyplSource,
-      lastId: options.start,
       limit: options.batchSize
     }
+    if (options.start) params.lastId = options.start
+    if (options.ids) params.ids = options.ids
 
     if (options.lastUpdatedDate) {
       // If lastUpdatedDate used, let's first subtract 1s because we know
@@ -122,7 +126,7 @@ class Reposter {
     // Closured handler for successful respost requests:
     const handleResponse = (resp) => {
       // Make sure we received a valid response with `limit` and `lastId`:
-      if (!resp || !resp.limit || (typeof resp.limit) !== 'number' || (!resp.lastId && !resp.lastUpdatedDate)) throw new UpstreamError(`Invalid response from ${path}: ${JSON.stringify(resp)}`)
+      if (!resp || !resp.limit || (typeof resp.limit) !== 'number' || (!resp.ids && !resp.lastId && !resp.lastUpdatedDate)) throw new UpstreamError(`Invalid response from ${path}: ${JSON.stringify(resp)}`)
       // If querying by lastId, make sure the returned `lastId` represents forward progress:
       if (options.start && resp.lastId <= options.start) throw new UpstreamError(`Response from ${path} gave non-incrementing lastId: ${resp.lastId}`)
 
@@ -141,7 +145,8 @@ class Reposter {
       let progressLabel = ''
       if (progressRatio) progressLabel = `, progress: ${(progressRatio * 100).toFixed(2)}%`
 
-      let recurse = !options.limit || processedCount < options.limit
+      let recurse = !options.ids && (!options.limit || processedCount < options.limit)
+      // console.log('recurse=', recurse, `${!options.ids} && (!${options.limit} || ${processedCount} < ${options.limit}`)
 
       // If processing by lastUpdatedDate, have we reached lastUpdatedDateStop?
       if (options.lastUpdatedDate && options.lastUpdatedDateStop && (new Date(resp.lastUpdatedDate)) >= options.lastUpdatedDateStop) recurse = false
@@ -167,7 +172,7 @@ class Reposter {
       }
     }
 
-    this.logger.debug('Reposter: POSTING to ' + process.env.NYPL_API_BASE_URL + path, params)
+    this.logger.debug('Reposter: POSTING to ' + process.env.NYPL_API_BASE_URL + path, JSON.stringify(params))
     return this.doPost(path, params).then(handleResponse)
       .catch((e) => {
         if (e && e.name === 'NoMoreRecordsError') {
@@ -204,7 +209,7 @@ class Reposter {
         if (body && body.statusCode && body.statusCode >= 400) throw new UpstreamError(`Repost: Received ${body.statusCode} from ${path}`, { body })
 
         // Check for errors like bodies that only contain {"message":"Endpoint request timed out"}
-        if (!body || !body.lastId) throw new UpstreamError(`Invalid response from ${path}: ${JSON.stringify(body)}`)
+        if (!body || (!body.lastId && !body.ids)) throw new UpstreamError(`Invalid response from ${path}: ${JSON.stringify(body)}`)
 
         return body
       })
@@ -215,7 +220,7 @@ class Reposter {
           throw e
         }
 
-        this.logger.error(`Reposter: Error posting to ${path}, retry ${retryCount}`, { params })
+        this.logger.error(`Reposter: Error posting to ${path}, retry ${retryCount}: ${e}`, { params })
 
         if (retryCount < MAX_RETRIES) {
           // Compute exponential backoff delay (1s, 9s, 27s, 81s, 243s, etc):

--- a/run.js
+++ b/run.js
@@ -2,13 +2,16 @@ const dotenv = require('dotenv')
 const minimist = require('minimist')
 const fs = require('fs')
 const path = require('path')
+const prompt = require('prompt')
 
 const argv = minimist(process.argv, {
   default: {
     start: '',
+    ids: '',
     batchSize: 100,
     batchDelay: 0
-  }
+  },
+  string: ['ids']
 })
 
 if (!argv.envfile || !fs.existsSync(argv.envfile)) throw new Error('Must specify --envfile')
@@ -16,39 +19,131 @@ dotenv.config({ path: argv.envfile })
 
 const Reposter = require('./lib/reposter.js')
 
-const which = argv._[2]
+let which = argv._[2]
 let nyplSource = argv._[3]
 // Validate nyplSource:
-nyplSource = ['sierra-nypl', 'recap-pul', 'recap-cul'].indexOf(nyplSource) < 0 ? null : nyplSource
+nyplSource = ['sierra-nypl', 'recap-pul', 'recap-cul', 'recap-hl'].indexOf(nyplSource) < 0 ? null : nyplSource
 
-const start = argv.start
-const limit = argv.limit
-const batchSize = argv.batchSize
-const batchDelay = argv.batchDelay
+let start = argv.start
+let ids = argv.ids.split(',').filter((id) => id)
+let limit = argv.limit
+let batchSize = argv.batchSize
+let batchDelay = argv.batchDelay
 let lastUpdatedDate = argv.lastUpdatedDate
 let lastUpdatedDateStop = argv.lastUpdatedDateStop
 
-if (!which || ['bibs', 'items'].indexOf(which) < 0) throw new Error('First argument must specify bibs/items')
-if (!nyplSource && !lastUpdatedDate) throw new Error('Second argument must specify valid nyplSource')
-if (limit && (typeof limit) !== 'number') throw new Error('Invalid limit. Must be numeric')
-if (batchSize && (typeof batchSize) !== 'number') throw new Error('Invalid batchSize. Must be numeric')
-if (batchDelay && (typeof batchDelay) !== 'number') throw new Error('Invalid batchDelay. Must be numeric')
-if (lastUpdatedDate) lastUpdatedDate = new Date(lastUpdatedDate)
-if (lastUpdatedDateStop) lastUpdatedDateStop = new Date(lastUpdatedDateStop)
-
-console.log([
-  `Running repost on ${which}`,
-  lastUpdatedDate ? `from timestamp ${lastUpdatedDate} to ${lastUpdatedDateStop}` : `start at '${start}'`,
-  limit ? `limit ${limit} in batches of ${batchSize}` : ' no limit',
-  batchDelay ? ` with ${batchDelay}ms batch delay}` : ''
-].join(', '))
-
-// Build logging path using env (e.g. production), source, and type
-const loggingNamespace = `${path.basename(argv.envfile, '.env')}-${nyplSource}-${which}`
-const reposter = new Reposter({ loggingNamespace })
-
-reposter.repost(which, nyplSource, { start, limit, batchSize, batchDelay, lastUpdatedDate, lastUpdatedDateStop })
-  .catch((e) => {
-    console.log(`Encountered error: ${e.name}\n  ${e.message}`)
+function promptWithDefault (question, defaultValue) {
+  return new Promise((resolve, reject) => {
+    prompt.start()
+    prompt.get(question, (e, result) => {
+      resolve(result[question] || defaultValue)
+    })
   })
+}
 
+function arrayChunks (arr, chunkSize) {
+  const groups = []
+  let i = 0
+  while (i < arr.length) {
+    groups.push(arr.slice(i, i += chunkSize))
+  }
+  return groups
+}
+
+function runWithOptions () {
+  if (!which || ['bibs', 'items'].indexOf(which) < 0) throw new Error('First argument must specify bibs/items')
+  if (!nyplSource && !lastUpdatedDate) throw new Error('Second argument must specify valid nyplSource')
+  if (limit && (typeof limit) !== 'number') throw new Error('Invalid limit. Must be numeric')
+  if (batchSize && (typeof batchSize) !== 'number') throw new Error('Invalid batchSize. Must be numeric')
+  if (batchDelay && (typeof batchDelay) !== 'number') throw new Error('Invalid batchDelay. Must be numeric')
+  if (lastUpdatedDate) lastUpdatedDate = new Date(lastUpdatedDate)
+  if (lastUpdatedDateStop) lastUpdatedDateStop = new Date(lastUpdatedDateStop)
+
+  console.log([
+    `Running repost on ${which}`,
+    ids ? `for ids ${ids.join(', ')}` : '',
+    lastUpdatedDate ? `from timestamp ${lastUpdatedDate} to ${lastUpdatedDateStop}` : `start at '${start}'`,
+    limit ? `limit ${limit} in batches of ${batchSize}` : ' no limit',
+    batchDelay ? ` with ${batchDelay}ms batch delay}` : ''
+  ].join(', '))
+
+  // Build logging path using env (e.g. production), source, and type
+  const loggingNamespace = `${path.basename(argv.envfile, '.env')}-${nyplSource}-${which}`
+  const reposter = new Reposter({ loggingNamespace })
+
+  if (argv.dryrun) {
+    console.log(`reposter.repost(${which}, ${nyplSource}, ${JSON.stringify({ start, ids, limit, batchSize, batchDelay, lastUpdatedDate, lastUpdatedDateStop })})`)
+    return Promise.resolve()
+  } else {
+    return reposter.repost(which, nyplSource, { start, ids, limit, batchSize, batchDelay, lastUpdatedDate, lastUpdatedDateStop })
+      .catch((e) => {
+        console.log(`Encountered error: ${e.name}\n  ${e.message}`)
+      })
+  }
+}
+
+let csvChunkIndex = 0
+function runOverCsv (chunks) {
+  ids = chunks[csvChunkIndex]
+
+  if (ids && ids.length > 0) {
+    runWithOptions()
+      .then(() => {
+        csvChunkIndex += 1
+
+        console.log(`Finished processing chunk ${csvChunkIndex} of ${chunks.length}`)
+
+        setTimeout(() => runOverCsv(chunks), 100)
+      })
+  } else {
+    console.log('All done')
+  }
+}
+
+if (!which && !nyplSource) {
+  prompt.start()
+  prompt.get({
+    properties: {
+      which: {
+        description: 'Repost bibs or items?',
+        pattern: /^(bibs|items)$/,
+        default: 'bibs',
+        required: true
+      },
+      nyplSource: {
+        description: 'NYPL Source?',
+        pattern: /^(sierra-nypl|recap-\w{2,3})$/,
+        default: 'sierra-nypl',
+        required: true
+      },
+      ids: {
+        description: 'Specific ids?',
+        pattern: /^(\d+,)*\d+/,
+        before: (v) => v.split(',')
+      }
+    }
+  }, (err, result) => {
+    which = result.which
+    nyplSource = result.nyplSource
+    ids = result.ids
+
+    runWithOptions();
+
+    let cmd = `node run ${which} ${nyplSource} --envfile ${argv.envfile}`
+    if (ids) cmd += ` --ids ${ids.join(',')}`
+    console.log('To replay this:')
+    console.log(cmd)
+  })
+} else if (argv.csv) {
+  let csv = fs.readFileSync(argv.csv, 'utf8')
+    .split("\n")
+  if (argv.offset) csv = csv.slice(argv.offset)
+  if (limit) csv = csv.slice(0, limit)
+
+  // the --ids flag seems to have a functional limit of 25
+  const chunks = arrayChunks(csv, Math.min(argv.batchSize || 25, 25))
+  runOverCsv(chunks)
+
+} else {
+  runWithOptions()
+}


### PR DESCRIPTION
This improves support for pushing arbitrary ids through. In particular, it adds support for pushing a whole CSV of bib/item ids through.